### PR TITLE
Ensure HMAC cache is updated on `get`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # webkms-client ChangeLog
 
+## 2.3.1 - 2021-02-xx
+
+### Fixed
+- Ensure HMAC cache is updated on `get`.
+
 ## 2.3.2 - 2020-09-30
 
 ### Fixed

--- a/Hmac.js
+++ b/Hmac.js
@@ -42,7 +42,11 @@ export class Hmac {
     this.capability = capability;
     this.invocationSigner = invocationSigner;
     this.kmsClient = kmsClient;
-    this.cache = new LRU({max: MAX_CACHE_SIZE, maxAge: MAX_CACHE_AGE});
+    this.cache = new LRU({
+      max: MAX_CACHE_SIZE,
+      maxAge: MAX_CACHE_AGE,
+      updateAgeOnGet: true
+    });
     this._pruneCacheTimer = null;
   }
 


### PR DESCRIPTION
The default is not to update the age of an item in the cache, which I believe is the opposite default we were expecting. This patches it.