### PR TITLE
Strip `ZCAP_ROOT_PREFIX` when parsing invocation target on root zcaps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # webkms-client ChangeLog
 
+## 12.1.1 - 2023-08-xx
+
+### Fixed
+- Ensure that when using a root zcap with `fromCapability` static helper
+  functions, the invocation target is calculated correctly.
+
 ## 12.1.0 - 2022-09-15
 
 ### Added

--- a/lib/KmsClient.js
+++ b/lib/KmsClient.js
@@ -758,7 +758,7 @@ export class KmsClient {
           'If "capability" is a string, it must be a root capability.');
       }
       invocationTarget = decodeURIComponent(
-        capability.substring(ZCAP_ROOT_PREFIX));
+        capability.substring(ZCAP_ROOT_PREFIX.length));
     } else if(typeof capability === 'object') {
       ({invocationTarget} = capability);
     }


### PR DESCRIPTION
When calling `KeyAgreementKey.fromCapability` with a root capability, the `ZCAP_ROOT_PREFIX` was not being removed when calculating the invocation target.