### PR TITLE
Assign `cause.data` to `error.data`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # webkms-client ChangeLog
 
+## 13.0.1 - 2023-09-xx
+
+### Fixed
+- Assign `cause.data` to `error.data` in `_handleClientError` helper.
+  `error.data` was inadvertently removed in `v12.1.2`.
+
 ## 13.0.0 - 2023-09-13
 
 ### Changed

--- a/lib/KmsClient.js
+++ b/lib/KmsClient.js
@@ -790,6 +790,9 @@ function _handleClientError({
     error.status = 404;
   } else {
     error = new Error(`WebKMS client error: ${errorMessage}`);
+    if(cause.data) {
+      error.data = cause.data;
+    }
     if(cause.status) {
       error.status = cause.status;
     }


### PR DESCRIPTION
This fix will be backported to the 12.x release as well.