### PR TITLE
Throw error for unsupported key algorithms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # webkms-client ChangeLog
 
+## 14.1.2 - 2024-xx-xx
+
+### Changed
+- Throw error from `AsymmetricKey.getAlgorithm()` if an unsupported encoded key
+  algorithm is found. This may be indirectly called from the constructor and
+  other functions.
+
 ## 14.1.1 - 2024-07-10
 
 ### Added

--- a/lib/AsymmetricKey.js
+++ b/lib/AsymmetricKey.js
@@ -130,7 +130,8 @@ export class AsymmetricKey {
   }
 
   /**
-   * Gets the JOSE algorithm from a key description.
+   * Gets the JOSE algorithm from a key description. Throws error if the
+   * encoded key algorithm is not supported.
    *
    * @param {object} options - The options to use.
    * @param {object} options.keyDescription - A key description.
@@ -142,7 +143,12 @@ export class AsymmetricKey {
     // presently all supported key types will have a base58-multikey-header
     // value that is only 4 characters long
     const prefix = publicKeyMultibase?.slice(0, 4);
-    return BASE58_MULTIKEY_HEADER_TO_JOSE.get(prefix);
+    const algorithm = BASE58_MULTIKEY_HEADER_TO_JOSE.get(prefix);
+    if(!algorithm) {
+      throw new Error(
+        `Unsupported key description public key prefix: "${prefix}".`);
+    }
+    return algorithm;
   }
 
   /**

--- a/tests/20-AsymmetricKey.spec.js
+++ b/tests/20-AsymmetricKey.spec.js
@@ -18,6 +18,12 @@ const keys = new Map([
   ['secp256k1', 'did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme']
 ]);
 
+const badKeys = new Map([
+  // key from a test with unkonwn 'zUC6' prefix
+  // eslint-disable-next-line
+  ['Bls12381G2', 'did:key:zUC6zwkczByHEDfap8UJdBwLDeiTYn2xUBq5AhYDnH3Actf9RgdvVF3Rqc2DaYh8j6JysZ6HLidVxM2Y2AhTtM7a5GefA2DGv6JJuSaTJ7ov1jtCnQLmAFYJoovhdzj2kivX9ev'],
+]);
+
 describe('AsymmetricKey API', () => {
   describe('should create key from keyDescription', () => {
     for(const [keyType, did] of keys) {
@@ -35,6 +41,26 @@ describe('AsymmetricKey API', () => {
           keyType,
           `Expected "key.algorithm" to be ${keyType}`
         );
+      });
+    }
+  });
+  describe('should fail for bad keys', () => {
+    for(const [keyType, did] of badKeys) {
+      it(`key type ${keyType}`, async () => {
+        let error;
+        let key;
+        try {
+          const keyDescription = {
+            id: did,
+            type: keyType,
+            publicKeyMultibase: did.slice(8)
+          };
+          key = new AsymmetricKey({keyDescription});
+        } catch(e) {
+          error = e;
+        }
+        should.exist(error, 'Expected error to exist');
+        should.not.exist(key, 'Expected key to not exist');
       });
     }
   });


### PR DESCRIPTION
Throw error from `AsymmetricKey.getAlgorithm()` if an unsupported encoded key algorithm is found. This may be indirectly called from the constructor and other functions.

This helps when unsupported or bad key data is used which would previously be partially processed but with the algorithm field set to undefined leading to later issues that were difficult to debug.