### PR TITLE
Update generate key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## 14.3.0 - 2025-01-dd
 
-### Changed
-- Update generateKey to create a specific, non-recommended key type.
+### Added
+- Allow a more specific key type to be specified in `generateKey()`. This
+  change is backwards compatible, however, the `type` parameter should
+  now carry the specific key type whereas it was previously used to specify
+  the key category (e.g., `asymmetric`, `symmetric`). This key category
+  should now be specified via the new parameter `category`. The existing
+  category values are still usable in the `type` parameter, but this use
+  is deprecated.
 
 ## 14.2.0 - 2025-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # webkms-client ChangeLog
 
+## 14.3.0 - 2025-01-dd
+
+### Changed
+- Update generateKey to create a specific, non-recommended key type.
+
 ## 14.2.0 - 2025-05-22
 
 ### Changed

--- a/lib/KeystoreAgent.js
+++ b/lib/KeystoreAgent.js
@@ -60,7 +60,14 @@ export class KeystoreAgent {
    * await generateKey({type: 'keyAgreement'})
    *
    * @param {object} options - The options to use.
-   * @param {string} options.type - The type of key to create (e.g., `hmac`).
+   * @param {object} options.category - The category of the key
+   *   ('asymmetric' | 'hmac' | 'keyAgreement' | 'kek').
+   * @param {object} [options.type] - The specific key type expressed
+   *   as a URL (e.g., `urn:webkms:multikey:P-256`); this can be omitted
+   *   to use the default key type for the given `category` and `version`
+   *   combination or, for backwards compatibility, a key category
+   *   value can be passed instead of using `category`, but this use is
+   *   deprecated.
    * @param {object} [options.capability] - The authorization capability to
    *   use to authorize generating a key; the root zcap will be used if not
    *   provided.
@@ -74,16 +81,15 @@ export class KeystoreAgent {
    * @param {string} [options.version=recommended] - `fips` to
    *   use FIPS-compliant ciphers, `recommended` to use the latest recommended
    *   ciphers.
-   * @param {object} options.category - The category of the key
-   *   (e.g. 'hmac', 'asymmetric').
    *
    * @returns {Promise<object>} An Hmac, Kek, AsymmetricKey, or KeyAgreementKey
    *   instance.
    */
   async generateKey({
-    type, capability, maxCapabilityChainLength,
+    category, type,
+    capability, maxCapabilityChainLength,
     publicAlias, publicAliasTemplate,
-    version = 'recommended', category
+    version = 'recommended'
   } = {}) {
     _assertVersion(version);
 

--- a/lib/KeystoreAgent.js
+++ b/lib/KeystoreAgent.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2019-2024 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2026 Digital Bazaar, Inc. All rights reserved.
  */
 import {AsymmetricKey} from './AsymmetricKey.js';
 import {CATEGORY_TO_CLASS} from './categoryToClass.js';
@@ -74,8 +74,8 @@ export class KeystoreAgent {
    * @param {string} [options.version=recommended] - `fips` to
    *   use FIPS-compliant ciphers, `recommended` to use the latest recommended
    *   ciphers.
-   * @param {object} [options.category] - The category of the a specific
-   *   non-recommended key type (e.g. 'hmac', 'asymmetric').
+   * @param {object} options.category - The category of the key
+   *   (e.g. 'hmac', 'asymmetric').
    *
    * @returns {Promise<object>} An Hmac, Kek, AsymmetricKey, or KeyAgreementKey
    *   instance.
@@ -91,7 +91,7 @@ export class KeystoreAgent {
     // other standardized key wrapping algorithm
     const keyDetails = RECOMMENDED_KEYS.get(type) ??
       {Class: CATEGORY_TO_CLASS.get(category), type};
-    if(!keyDetails.Class && keyDetails.type) {
+    if(!(keyDetails.Class && keyDetails.type)) {
       throw new Error(`Unknown key type "${type}".`);
     }
     const {type: fullType, Class} = keyDetails;

--- a/lib/KeystoreAgent.js
+++ b/lib/KeystoreAgent.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2019-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import {AsymmetricKey} from './AsymmetricKey.js';
+import {CATEGORY_TO_ClASS} from './categoryToClass.js';
 import {Hmac} from './Hmac.js';
 import {Kek} from './Kek.js';
 import {KeyAgreementKey} from './KeyAgreementKey.js';
@@ -73,6 +74,8 @@ export class KeystoreAgent {
    * @param {string} [options.version=recommended] - `fips` to
    *   use FIPS-compliant ciphers, `recommended` to use the latest recommended
    *   ciphers.
+   * @param {object} [options.category] - The category of the a specific
+   *   non-recommended key type (e.g. 'hmac', 'asymmetric').
    *
    * @returns {Promise<object>} An Hmac, Kek, AsymmetricKey, or KeyAgreementKey
    *   instance.
@@ -80,14 +83,15 @@ export class KeystoreAgent {
   async generateKey({
     type, capability, maxCapabilityChainLength,
     publicAlias, publicAliasTemplate,
-    version = 'recommended'
+    version = 'recommended', category
   } = {}) {
     _assertVersion(version);
 
     // for the time being, fips and recommended are the same; there is no
     // other standardized key wrapping algorithm
-    const keyDetails = RECOMMENDED_KEYS.get(type);
-    if(!keyDetails) {
+    const keyDetails = RECOMMENDED_KEYS.get(type) ??
+      {Class: CATEGORY_TO_ClASS.get(category), type};
+    if(!keyDetails.Class && keyDetails.type) {
       throw new Error(`Unknown key type "${type}".`);
     }
     const {type: fullType, Class} = keyDetails;

--- a/lib/KeystoreAgent.js
+++ b/lib/KeystoreAgent.js
@@ -60,9 +60,9 @@ export class KeystoreAgent {
    * await generateKey({type: 'keyAgreement'})
    *
    * @param {object} options - The options to use.
-   * @param {object} options.category - The category of the key
+   * @param {string} options.category - The category of the key
    *   ('asymmetric' | 'hmac' | 'keyAgreement' | 'kek').
-   * @param {object} [options.type] - The specific key type expressed
+   * @param {string} [options.type] - The specific key type expressed
    *   as a URL (e.g., `urn:webkms:multikey:P-256`); this can be omitted
    *   to use the default key type for the given `category` and `version`
    *   combination or, for backwards compatibility, a key category

--- a/lib/KeystoreAgent.js
+++ b/lib/KeystoreAgent.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2019-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import {AsymmetricKey} from './AsymmetricKey.js';
-import {CATEGORY_TO_ClASS} from './categoryToClass.js';
+import {CATEGORY_TO_CLASS} from './categoryToClass.js';
 import {Hmac} from './Hmac.js';
 import {Kek} from './Kek.js';
 import {KeyAgreementKey} from './KeyAgreementKey.js';
@@ -90,7 +90,7 @@ export class KeystoreAgent {
     // for the time being, fips and recommended are the same; there is no
     // other standardized key wrapping algorithm
     const keyDetails = RECOMMENDED_KEYS.get(type) ??
-      {Class: CATEGORY_TO_ClASS.get(category), type};
+      {Class: CATEGORY_TO_CLASS.get(category), type};
     if(!keyDetails.Class && keyDetails.type) {
       throw new Error(`Unknown key type "${type}".`);
     }

--- a/lib/categoryToClass.js
+++ b/lib/categoryToClass.js
@@ -9,6 +9,6 @@ import {KeyAgreementKey} from './KeyAgreementKey.js';
 export const CATEGORY_TO_CLASS = new Map([
   ['asymmetric', AsymmetricKey],
   ['hmac', Hmac],
-  ['keyAgreement',  KeyAgreementKey ],
+  ['keyAgreement', KeyAgreementKey ],
   ['kek', Kek ]
 ]);

--- a/lib/categoryToClass.js
+++ b/lib/categoryToClass.js
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) 2026 Digital Bazaar, Inc. All rights reserved.
+ */
+import {AsymmetricKey} from './AsymmetricKey.js';
+import {Hmac} from './Hmac.js';
+import {Kek} from './Kek.js';
+import {KeyAgreementKey} from './KeyAgreementKey.js';
+
+export const CATEGORY_TO_CLASS = new Map([
+  ['asymmetric', AsymmetricKey],
+  ['hmac', Hmac],
+  ['keyAgreement',  KeyAgreementKey ],
+  ['kek', Kek ]
+]);

--- a/lib/categoryToClass.js
+++ b/lib/categoryToClass.js
@@ -9,6 +9,6 @@ import {KeyAgreementKey} from './KeyAgreementKey.js';
 export const CATEGORY_TO_CLASS = new Map([
   ['asymmetric', AsymmetricKey],
   ['hmac', Hmac],
-  ['keyAgreement', KeyAgreementKey ],
-  ['kek', Kek ]
+  ['keyAgreement', KeyAgreementKey],
+  ['kek', Kek]
 ]);


### PR DESCRIPTION
#### _Resolves - update generateKey function_

---

### What kind of change does this PR introduce?

- feature extension

<br/>

### What is the current behavior?

- generateKey can only create keys that are from the RECOMMENDED_KEYS map

<br/>

### What is the new behavior?

- generateKey can create a key with a specified `type` and `category`

<br/>

### Does this PR introduce a breaking change?

- no

<br/>